### PR TITLE
Fix #19

### DIFF
--- a/src/py/idom/layout.py
+++ b/src/py/idom/layout.py
@@ -57,9 +57,15 @@ class Layout:
         return self._root.id
 
     async def apply(self, target: str, handler: str, data: dict):
-        model_state = self._state[target]
-        event_handler = model_state["event_handlers"][handler]
-        await event_handler(data)
+        if target in self._state:
+            # It is possible for an element in the frontend to produce an event
+            # associated with a backend model that has been deleted. We only handle
+            # events if the element exists in the backend.
+            model_state = self._state[target]
+            # If the element exists but the handler doesn't then something went wrong.
+            # So we allow the potential KeyError.
+            event_handler = model_state["event_handlers"][handler]
+            await event_handler(data)
 
     def animate(self, function: Callable):
         self._animate_queue.append(to_coroutine(function))


### PR DESCRIPTION
It is possible for events from the client to refer to elements
on the backend that have already been deleted. This is because
the frontend has not been sent the newly computed DOM model by
the time the event is produced - thus the target of the event
is stale.

In this case we now choose to ignore the event because the element
has been deleted.