### PR TITLE
html_to_vdom only returned first element

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # copied from prod.txt
-sanic>=18.12, <19.0
-typing-extensions==3.7.2, <4.0
+sanic >=18.12, <19.0
+typing-extensions >=3.7.2, <4.0
 
 # copied from dev.txt
 pytest

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,2 @@
-sanic>=18.12, <19.0
-typing-extensions==3.7.2, <4.0
+sanic >=18.12, <19.0
+typing-extensions >=3.7.2, <4.0

--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from .core import element, Element, Events, Layout
 from .widgets import node, Image, hotswap, display, html, Input

--- a/src/py/idom/tools.py
+++ b/src/py/idom/tools.py
@@ -70,7 +70,7 @@ _ModelTransform = Callable[[_ModelOrStr], None]
 
 def html_to_vdom(
     source: str, transform: Optional[_ModelTransform] = None
-) -> Dict[str, Any]:
+) -> List[Dict[str, Any]]:
     """Transform HTML into a DOM model
 
     Parameters:
@@ -92,10 +92,10 @@ class HtmlParser(_HTMLParser):
         if transform is not None:
             self._transform = transform
 
-    def model(self) -> Dict[str, Any]:
+    def model(self) -> List[Dict[str, Any]]:
         root: Dict[str, Any] = self._node_stack[0]
-        first_child: Dict[str, Any] = root["children"][0]
-        return first_child
+        root_children: List[Dict[str, Any]] = root["children"]
+        return root_children
 
     def feed(self, data: str) -> None:
         self._node_stack.append(self._make_node("div", {}))
@@ -110,6 +110,7 @@ class HtmlParser(_HTMLParser):
         current = self._node_stack[-1]
         current["children"].append(new)
         self._node_stack.append(new)
+        print(self._node_stack[0])
 
     def handle_endtag(self, tag: str) -> None:
         node = self._node_stack.pop(-1)

--- a/src/py/tests/test_tools.py
+++ b/src/py/tests/test_tools.py
@@ -50,7 +50,7 @@ def test_var_get():
     ],
 )
 def test_html_to_vdom(case):
-    assert html_to_vdom(case["source"]) == case["model"]
+    assert html_to_vdom(case["source"]) == [case["model"]]
 
 
 def test_html_to_vdom_transform():
@@ -60,20 +60,22 @@ def test_html_to_vdom_transform():
         if node["tagName"] == "a":
             node["attributes"]["style"] = {"color": "blue"}
 
-    assert html_to_vdom(source, make_links_blue) == {
-        "tagName": "p",
-        "children": [
-            "hello ",
-            {
-                "tagName": "a",
-                "children": ["world"],
-                "attributes": {"style": {"color": "blue"}},
-            },
-            " and ",
-            {
-                "tagName": "a",
-                "children": ["universe"],
-                "attributes": {"style": {"color": "blue"}},
-            },
-        ],
-    }
+    assert html_to_vdom(source, make_links_blue) == [
+        {
+            "tagName": "p",
+            "children": [
+                "hello ",
+                {
+                    "tagName": "a",
+                    "children": ["world"],
+                    "attributes": {"style": {"color": "blue"}},
+                },
+                " and ",
+                {
+                    "tagName": "a",
+                    "children": ["universe"],
+                    "attributes": {"style": {"color": "blue"}},
+                },
+            ],
+        }
+    ]


### PR DESCRIPTION
If your html looked like this:

```
<div/>
<p/>
```

The function only returned the model for the first div. Now it returns a list of models that are at the root level.

Also, bumps to version 0.4.1