### PR TITLE
Misc changes + 0.4.2 version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dist
 *.egg-info
 *.pytest_cache
 *.mypy_cache
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 <a href="https://travis-ci.com/rmorshea/idom">
   <img alt="Build Status" src="https://travis-ci.com/rmorshea/idom.svg?branch=master"/>
 </a>
-<a href="https://pypi.python.org/pypi/idom">
-  <img alt="Version Info" src="https://img.shields.io/pypi/v/spectate.svg"/>
-</a>
 <a href="https://github.com/rmorshea/idom/blob/master/LICENSE"/>
   <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-purple.svg">
+</a>
+<a href="https://pypi.python.org/pypi/idom">
+  <img alt="Version Info" src="https://img.shields.io/pypi/v/spectate.svg"/>
 </a>
 
 Libraries for creating and controlling interactive web pages with Python 3.6 and above.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 <a href="https://travis-ci.com/rmorshea/idom">
   <img alt="Build Status" src="https://travis-ci.com/rmorshea/idom.svg?branch=master"/>
 </a>
-<a href="https://github.com/rmorshea/idom/blob/master/LICENSE"/>
-  <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-purple.svg">
-</a>
 <a href="https://pypi.python.org/pypi/idom">
   <img alt="Version Info" src="https://img.shields.io/pypi/v/spectate.svg"/>
+</a>
+<a href="https://github.com/rmorshea/idom/blob/master/LICENSE"/>
+  <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-purple.svg">
 </a>
 
 Libraries for creating and controlling interactive web pages with Python 3.6 and above.

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -621,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,5 @@
 # copied from prod.txt
 sanic >=18.12, <19.0
-typing-extensions >=3.7.2, <4.0
 
 # copied from dev.txt
 pytest

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,1 @@
 sanic >=18.12, <19.0
-typing-extensions >=3.7.2, <4.0

--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from .core import element, Element, Events, Layout
 from .widgets import node, Image, hotswap, display, html, Input

--- a/src/py/tests/test_idom/test_tools.py
+++ b/src/py/tests/test_idom/test_tools.py
@@ -50,7 +50,10 @@ def test_var_get():
     ],
 )
 def test_html_to_vdom(case):
-    assert html_to_vdom(case["source"]) == [case["model"]]
+    assert html_to_vdom(case["source"]) == {
+        "tagName": "div",
+        "children": [case["model"]],
+    }
 
 
 def test_html_to_vdom_transform():
@@ -59,23 +62,27 @@ def test_html_to_vdom_transform():
     def make_links_blue(node):
         if node["tagName"] == "a":
             node["attributes"]["style"] = {"color": "blue"}
+        return node
 
-    assert html_to_vdom(source, make_links_blue) == [
-        {
-            "tagName": "p",
-            "children": [
-                "hello ",
-                {
-                    "tagName": "a",
-                    "children": ["world"],
-                    "attributes": {"style": {"color": "blue"}},
-                },
-                " and ",
-                {
-                    "tagName": "a",
-                    "children": ["universe"],
-                    "attributes": {"style": {"color": "blue"}},
-                },
-            ],
-        }
-    ]
+    expected = {
+        "tagName": "p",
+        "children": [
+            "hello ",
+            {
+                "tagName": "a",
+                "children": ["world"],
+                "attributes": {"style": {"color": "blue"}},
+            },
+            " and ",
+            {
+                "tagName": "a",
+                "children": ["universe"],
+                "attributes": {"style": {"color": "blue"}},
+            },
+        ],
+    }
+
+    assert html_to_vdom(source, make_links_blue) == {
+        "tagName": "div",
+        "children": [expected],
+    }


### PR DESCRIPTION
# Summary

Fixes several things:

1. `html_to_vdom` did not return the whole HTML model.
2. Reworks how the transform function is applied to the model after its been converted to VDOM.
3. Fixes typing issue with `Element` function signature.

## Return whole HTML model

If your html looked like this:

```
<div/>
<p/>
```

The function only returned the model for the first `div`. Now it returns a wrapper `div` around both elements.

## Reworks how transform is applied

The transform was a little difficult to work with given the time at which it was applied. It's more intuitive for the transform to get applied from the root node to leafs rather than the other way around. It also makes the underlying code a little easier to reason about.


## Fix `Element` function protocol type

The `Element` functions signature was previously defined by a `Protocol` with a `__call__` attribute, however this didn't really work as expected.

I wanted to enforce `(self: Element, *args: Any, **kwargs: Any)` where `*args, **kwargs` was actually optional (i.e. functions conforming to the protocol could accept any, or no other arguments besides `self`).

See https://github.com/python/mypy/issues/5876 for details.
