### PR TITLE
update intro notebook + handle relative socket URI in client

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,6 +1,0 @@
-# notebook checkpoints
-.ipynb_checkpoints
-
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -1,9 +1,9 @@
 import os
-from typing import Mapping, Any
+from typing import Mapping, Any, Optional
 
 
-def idom_websocket_url(port: int) -> str:
-    """Returns the URL of the websocket
+def example_uri_root(protocol: str, port: int) -> str:
+    """Returns the iDOM root URI for example notebooks
 
     When examples are running on mybinder.org or in a container created by
     jupyter-repo2docker this is not simply "localhost" or "127.0.0.1".
@@ -15,7 +15,15 @@ def idom_websocket_url(port: int) -> str:
     elif "JUPYTER_SERVER_URL" in os.environ:
         return "%s/proxy/%s" % (os.environ["JUPYTER_SERVER_URL"], port)
     else:
-        return "ws://127.0.0.1:%s" % port + "/stream"
+        return "%s://127.0.0.1:%s" % (protocol, port)
+
+
+class html_link:
+    def __init__(self, href: str, text: Optional[str] = None):
+        self.href, self.text = href, text
+
+    def _repr_html_(self) -> str:
+        return f"<a href='{self.href}' target='_blank'>{self.text or self.href}</a>"
 
 
 def pretty_dict_string(

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -1,27 +1,26 @@
 import os
-from collections.abc import Mapping
+from typing import Mapping, Any
 
 
-def localhost(protocol, port):
-    """Returns the host URL.
+def idom_websocket_url(port: int) -> str:
+    """Returns the URL of the websocket
 
     When examples are running on mybinder.org or in a container created by
     jupyter-repo2docker this is not simply "localhost" or "127.0.0.1".
     Instead we use a route produced by ``jupyter_server_proxy`` instead.
     """
     if "JUPYTERHUB_OAUTH_CALLBACK_URL" in os.environ:
-        protocol += "s"
-        form = protocol + "://hub.mybinder.org%s/proxy/%s"
         auth = os.environ["JUPYTERHUB_OAUTH_CALLBACK_URL"].rsplit("/", 1)[0]
-        return form % (auth, port)
+        return "%s/proxy/%s" % (auth, port)
     elif "JUPYTER_SERVER_URL" in os.environ:
         return "%s/proxy/%s" % (os.environ["JUPYTER_SERVER_URL"], port)
     else:
-        form = protocol + "://127.0.0.1:%s"
-        return form % port
+        return "ws://127.0.0.1:%s" % port + "/stream"
 
 
-def pretty_dict_string(value, indent=1, depth=0):
+def pretty_dict_string(
+    value: Mapping[Any, Any], indent: int = 1, depth: int = 0
+) -> str:
     """Simple function for printing out nested mappings."""
 
     last_indent = " " * (indent * depth)

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -64,13 +64,13 @@
    "outputs": [],
    "source": [
     "from idom.server.sanic import PerClientState\n",
-    "from example_utils import idom_websocket_url, pretty_dict_string\n",
+    "from example_utils import example_uri_root, html_link, pretty_dict_string\n",
     "\n",
-    "port=8765\n",
-    "websocket_url = idom_websocket_url(port)\n",
+    "websocket_url = example_uri_root(\"ws\", 8765) + \"/stream\"\n",
+    "webpage_url = html_link(example_uri_root(\"http\", 8765) + \"/client/index.html\")\n",
     "\n",
     "show, element = idom.hotswap()\n",
-    "PerClientState(element).daemon(\"0.0.0.0\", port, access_log=False)"
+    "PerClientState(element).daemon(\"0.0.0.0\", 8765, access_log=False)"
    ]
   },
   {
@@ -106,7 +106,23 @@
    "source": [
     "## Try it Out!\n",
     "\n",
-    "The following cells will display the output:"
+    "The following cells will display the output here. However you can also see the same thing in a standard web page:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "webpage_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you just want to see it here run the cell below..."
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -64,13 +64,13 @@
    "outputs": [],
    "source": [
     "from idom.server.sanic import PerClientState\n",
-    "from example_utils import localhost, pretty_dict_string\n",
+    "from example_utils import idom_websocket_url, pretty_dict_string\n",
     "\n",
-    "webpage_url = localhost('http', 8765) + '/client/index.html'\n",
-    "websocket_url = localhost('ws', 8765) + '/stream'\n",
+    "port=8765\n",
+    "websocket_url = idom_websocket_url(port)\n",
     "\n",
     "show, element = idom.hotswap()\n",
-    "PerClientState(element).daemon(\"0.0.0.0\", 8765, access_log=False)"
+    "PerClientState(element).daemon(\"0.0.0.0\", port, access_log=False)"
    ]
   },
   {
@@ -106,24 +106,7 @@
    "source": [
     "## Try it Out!\n",
     "\n",
-    "The following cells will display the output here. However you can also see the same thing in a standard web page:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print('Get a webpage that streams layout updates via a websocket:')\n",
-    "print(webpage_url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you just want to see it here run the cell below..."
+    "The following cells will display the output:"
    ]
   },
   {

--- a/src/js/packages/idom-layout/src/index.js
+++ b/src/js/packages/idom-layout/src/index.js
@@ -10,6 +10,22 @@ function updateDynamicElement(elementId) {
 }
 
 function Layout({ endpoint }) {
+    // handle relative endpoint URI
+    if ( endpoint.startsWith(".") || endpoint.startsWith("/") ) {
+        let loc = window.location;
+        let protocol;
+        if (loc.protocol === "https:") {
+            protocol = "wss:";
+        } else {
+            protocol = "ws:";
+        }
+        let new_uri = protocol + "//" + loc.host
+        if ( endpoint.startsWith(".") ) {
+            new_url += loc.pathname + "/"
+        }
+        endpoint =  new_uri + endpoint;
+    }
+
     const socket = useMemo(
         () => {
             return new WebSocket(endpoint);

--- a/src/py/idom/widgets/common.py
+++ b/src/py/idom/widgets/common.py
@@ -95,7 +95,7 @@ def hotswap(
 
     def swap(element: ElementConstructor, *args: Any, **kwargs: Any) -> None:
         last = last_element.get()
-        if last is not None:
+        if isinstance(last, Element):
             # because the hotswap is done via side-effects there's no way for
             # the layout to know to unmount the old element so we do it manually
             last.unmount()


### PR DESCRIPTION
The intro notebook is broken due to changes in MyBinder's hosting solution.

The gist: we should support relative URIs for the websocket location the client should connect to.

Allowing these relative URIs allows us to work around the change in MyBinder's hosting.

closes: #61 