### PR TITLE
make React a peer dependency

### DIFF
--- a/src/js/packages/idom-jupyter-widget-hook/package.json
+++ b/src/js/packages/idom-jupyter-widget-hook/package.json
@@ -8,7 +8,7 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
   },

--- a/src/js/packages/idom-layout/package.json
+++ b/src/js/packages/idom-layout/package.json
@@ -16,7 +16,9 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "del-cli": "^1.1.0",
+    "del-cli": "^1.1.0"
+  },
+  "peerDependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
   },

--- a/src/js/packages/idom-simple-client/package.json
+++ b/src/js/packages/idom-simple-client/package.json
@@ -9,7 +9,7 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
   },


### PR DESCRIPTION
Best practice to list react as a peer dependency in a package:

https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies