### PR TITLE
Refactor Sanic Server

### DIFF
--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1-a.1"
+__version__ = "0.5.1-a.2"
 
 from . import server
 


### PR DESCRIPTION
Makes it simpler to overwrite how the renderer is run.

Provides a new `SanicServerExtension._run_renderer(send, recv)`