### PR TITLE
Catch Error From Lazy Eval'd Components

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -667,7 +667,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "antd = idom.Package(\"https://dev.jspm.io/antd\")\n",
+    "antd = idom.Import(\"https://dev.jspm.io/antd\")\n",
     "\n",
     "\n",
     "@idom.element\n",

--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1-a.2"
+__version__ = "0.5.1-a.3"
 
 from . import server
 

--- a/src/py/idom/widgets/common.py
+++ b/src/py/idom/widgets/common.py
@@ -172,7 +172,7 @@ class ImportElement(AbstractElement):
     async def render(self) -> Any:
         source = {
             "id": hex(hash(self._package)),
-            "source": f"import('{self._package}').then(pkg => pkg.default);",
+            "source": f"return import('{self._package}').then(pkg => pkg.default);",
             "fallback": self._fallback,
         }
         return node(self._tag, importSource=source, *self._children, **self._attributes)


### PR DESCRIPTION
This basically prevents the app from catastrophically failing if there's a syntax error in the eval'd string or while rendering the resulting component.

Also changes API for custom React components. Instead of simple eval, you need to return the components you want to export in an object:

```python
module = idom.Module("""
function Button({onClick}) {
    return (
    	<button onClick={onClick}>
        	Click Me!
        </button>
    );
}

return {
    Button: Button
};
""")

button = module.Button()