### PR TITLE
Remove Magic From JS Evaluation

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -667,7 +667,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "antd = idom.Import(\"https://dev.jspm.io/antd\")\n",
+    "antd = idom.Import(\"antd")\n",
     "\n",
     "\n",
     "@idom.element\n",

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -667,7 +667,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "antd = idom.Import(\"antd")\n",
+    "antd = idom.Import(\"antd\")\n",
     "\n",
     "\n",
     "@idom.element\n",

--- a/src/js/packages/idom-layout/src/lazy-component.js
+++ b/src/js/packages/idom-layout/src/lazy-component.js
@@ -89,14 +89,14 @@ function getPathProperty(obj, prop) {
 
 function evalInContext(jsx) {
     const transform = babelTransform(
-        "() => {let React = this.React;" + jsx + "}",
+        "const React = this.React;\n" + jsx,
         {
             presets: ["react"],
             plugins: [require("@babel/plugin-syntax-dynamic-import")]
         }
     );
     return function() {
-        return eval(transform.code)();
+        return eval(transform.code);
     }.call({
         React: React
     });

--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0-a.3"
+__version__ = "0.6.0-a.4"
 
 from . import server
 

--- a/src/py/idom/__init__.py
+++ b/src/py/idom/__init__.py
@@ -7,7 +7,7 @@ from .core.events import event, Events
 from .core.layout import Layout
 
 from .widgets import html
-from .widgets.common import node, hotswap, Import, Module
+from .widgets.common import node, hotswap, Eval, Import
 from .widgets.display import display
 from .widgets.inputs import Input
 from .widgets.images import Image
@@ -26,7 +26,7 @@ __all__ = [
     "Var",
     "node",
     "Image",
-    "Module",
+    "Eval",
     "Import",
     "hotswap",
     "display",

--- a/src/py/idom/widgets/__init__.py
+++ b/src/py/idom/widgets/__init__.py
@@ -1,7 +1,7 @@
-from .common import node, Module, Import, hotswap
+from .common import node, Eval, Import, hotswap
 from .display import display
 from .inputs import Input
 from .images import Image
 from . import html
 
-__all__ = ["display", "node", "Image", "hotswap", "html", "Input", "Module", "Import"]
+__all__ = ["display", "node", "Image", "hotswap", "html", "Input", "Eval", "Import"]


### PR DESCRIPTION
Before we wrapped the JS source provided to the client in a function so you could use `return ...` to indicate what you wanted to export. That's nice and all, but it's magic that doesn't really need to be there.

Also:
- Rename, `idom.Module` to `idom.Eval` to be more explicit.
- Fix binder example (now uses jspm.io automatically)