### PR TITLE
IPv6 maps localhost to ::1

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -76,7 +76,7 @@
     "webpage_url = html_link(example_uri_root(\"http\", 8765) + \"/client/index.html\")\n",
     "\n",
     "mount, element = idom.hotswap()\n",
-    "PerClientState(element).daemon(\"localhost\", 8765, access_log=False)\n",
+    "PerClientState(element).daemon(\"127.0.0.1\", 8765, access_log=False)\n",
     "\n",
     "def display(*args, **kwargs):\n",
     "    element, *args = args\n",


### PR DESCRIPTION
As per the IPv6 spec localhost maps to `::1` so we need to hard-code `127.0.0.1`